### PR TITLE
Protect installer with explicit mode and server restrictions

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,8 @@
+<Files "install.php">
+    Require all denied
+</Files>
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteRule ^install/ - [F,L]
+</IfModule>

--- a/config.inc.php
+++ b/config.inc.php
@@ -11,6 +11,9 @@ define('__TYPECHO_THEME_DIR__', '/usr/themes');
 // admin directory (relative path)
 define('__TYPECHO_ADMIN_DIR__', '/admin/');
 
+// installation mode flag
+define('INSTALL_MODE', false);
+
 // register autoload
 require_once __TYPECHO_ROOT_DIR__ . '/var/Typecho/Common.php';
 

--- a/install.php
+++ b/install.php
@@ -1,8 +1,17 @@
 <?php
 
-if (!file_exists(dirname(__FILE__) . '/config.inc.php')) {
+if (file_exists(__DIR__ . '/config.inc.php')) {
+    require_once __DIR__ . '/config.inc.php';
+
+    if (!defined('INSTALL_MODE') || INSTALL_MODE !== true) {
+        http_response_code(403);
+        exit('Installation is disabled');
+    }
+
+    $installDb = \Typecho\Db::get();
+} else {
     // site root path
-    define('__TYPECHO_ROOT_DIR__', dirname(__FILE__));
+    define('__TYPECHO_ROOT_DIR__', __DIR__);
 
     // plugin directory (relative path)
     define('__TYPECHO_PLUGIN_DIR__', '/usr/plugins');
@@ -18,9 +27,6 @@ if (!file_exists(dirname(__FILE__) . '/config.inc.php')) {
 
     // init
     \Typecho\Common::init();
-} else {
-    require_once dirname(__FILE__) . '/config.inc.php';
-    $installDb = \Typecho\Db::get();
 }
 
 /**

--- a/install/.htaccess
+++ b/install/.htaccess
@@ -1,0 +1,1 @@
+Require all denied

--- a/install/Mysql.php
+++ b/install/Mysql.php
@@ -1,4 +1,4 @@
-<?php if(!defined('__TYPECHO_ROOT_DIR__')) exit; ?>
+<?php if(!defined('__TYPECHO_ROOT_DIR__') || !defined('INSTALL_MODE') || INSTALL_MODE !== true) exit; ?>
 
 <ul class="typecho-option">
     <li>

--- a/install/Pgsql.php
+++ b/install/Pgsql.php
@@ -1,4 +1,4 @@
-<?php if(!defined('__TYPECHO_ROOT_DIR__')) exit; ?>
+<?php if(!defined('__TYPECHO_ROOT_DIR__') || !defined('INSTALL_MODE') || INSTALL_MODE !== true) exit; ?>
 <ul class="typecho-option">
     <li>
         <label class="typecho-label" for="dbHost"><?php _e('数据库地址'); ?></label>

--- a/install/SQLite.php
+++ b/install/SQLite.php
@@ -1,4 +1,4 @@
-<?php if(!defined('__TYPECHO_ROOT_DIR__')) exit; ?>
+<?php if(!defined('__TYPECHO_ROOT_DIR__') || !defined('INSTALL_MODE') || INSTALL_MODE !== true) exit; ?>
 <?php $defaultDir = __TYPECHO_ROOT_DIR__ . '/usr/' . uniqid() . '.db'; ?>
 <ul class="typecho-option">
     <li>


### PR DESCRIPTION
## Summary
- add `INSTALL_MODE` constant and require it in install scripts
- block access to installer endpoints via `.htaccess`

## Testing
- `php -l config.inc.php`
- `php -l install.php`
- `php -l install/Mysql.php`
- `php -l install/Pgsql.php`
- `php -l install/SQLite.php`
- `apachectl -t` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f53a593a88331add83d559e2880a0