### PR TITLE
Sanitize sitemap node values

### DIFF
--- a/usr/plugins/Sitemap/SiteMapLogic.php
+++ b/usr/plugins/Sitemap/SiteMapLogic.php
@@ -29,7 +29,11 @@ class SiteMapLogic
      */
     public function setNode($loc, $lastmod = null, $changefreq = 'always', $priority = 0.7)
     {
-        $lastmod     = $lastmod ?: time();
+        $loc        = htmlspecialchars($loc, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+        $changefreq = htmlspecialchars($changefreq, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+        $priority   = is_numeric($priority) ? max(0.0, min((float) $priority, 1.0)) : 0.7;
+
+        $lastmod    = $lastmod ?: time();
         $this->nodes .= "\t<url>\n" .
             "\t\t<loc>{$loc}</loc>\n" .
             "\t\t<lastmod>" . date('c', $lastmod) . "</lastmod>\n" .


### PR DESCRIPTION
## Summary
- Escape location and change frequency values in sitemap nodes using `htmlspecialchars`
- Validate numeric priority within 0-1 range

## Testing
- `php -l usr/plugins/Sitemap/SiteMapLogic.php`


------
https://chatgpt.com/codex/tasks/task_e_689f69e9735083319aadf02e714ba5b5