### PR TITLE
Add safeguards to release version retrieval

### DIFF
--- a/usr/plugins/Sitemap/Plugin.php
+++ b/usr/plugins/Sitemap/Plugin.php
@@ -130,8 +130,16 @@ class Sitemap_Plugin implements Typecho_Plugin_Interface
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_USERAGENT, "typecho-sitemap-plugin");
         $res  = curl_exec($ch);
-        $data = json_decode($res, JSON_UNESCAPED_UNICODE);
-        return $data['tag_name'];
+        if ($res === false) {
+            error_log('Sitemap getNewRelease curl error: ' . curl_error($ch));
+            return __TYPECHO_PLUGIN_SITEMAP_VERSION__;
+        }
+        $data = json_decode($res, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            error_log('Sitemap getNewRelease json decode error: ' . json_last_error_msg());
+            return __TYPECHO_PLUGIN_SITEMAP_VERSION__;
+        }
+        return $data['tag_name'] ?? __TYPECHO_PLUGIN_SITEMAP_VERSION__;
     }
 
 }


### PR DESCRIPTION
## Summary
- Log cURL errors and return current version when release lookup fails
- Validate JSON decode results before using data

## Testing
- `php -l usr/plugins/Sitemap/Plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_689f69ec699c833190b3328a63757863