### PR TITLE
Handle missing sitemap plugin options

### DIFF
--- a/usr/plugins/Sitemap/Plugin.php
+++ b/usr/plugins/Sitemap/Plugin.php
@@ -107,11 +107,19 @@ class Sitemap_Plugin implements Typecho_Plugin_Interface
      *
      * @access public
      * @return void
-     * @throws Typecho_Plugin_Exception
      */
     public static function updateTip()
     {
-        $option = Helper::options()->plugin('Sitemap');
+        try {
+            $option = Helper::options()->plugin('Sitemap');
+        } catch (Typecho_Plugin_Exception $e) {
+            Helper::configPlugin('Sitemap', [
+                'updateTip' => 1,
+                'cacheTime' => 86400,
+                'flushCache' => 0,
+            ]);
+            return;
+        }
         if ($option->updateTip == 1) {
             $date = new Typecho_Date();
             $date = $date->timeStamp;


### PR DESCRIPTION
## Summary
- wrap plugin option lookup in try-catch to avoid Typecho\_Plugin\_Exception
- initialize default sitemap config when options are missing

## Testing
- `php -l usr/plugins/Sitemap/Plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_689f6e84fcb08331aa0f1a5bb5575709