### PR TITLE
Check root favicon existence

### DIFF
--- a/usr/themes/jjj/php_modules/default_head.php
+++ b/usr/themes/jjj/php_modules/default_head.php
@@ -18,14 +18,11 @@ content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale
 <title><?php blogTitle($this);?></title>
 
 <!-- favicon -->
-<link rel="apple-touch-icon" sizes="180x180" href="<?php $this->options->themeUrl('/static/images/favicon/apple-touch-icon.png');?>">
-<link rel="icon" type="image/png" sizes="32x32" href="<?php $this->options->themeUrl('/static/images/favicon/favicon-32x32.png');?>">
-<link rel="icon" type="image/png" sizes="16x16" href="<?php $this->options->themeUrl('/static/images/favicon/favicon-16x16.png');?>">
-<link rel="manifest" href="<?php $this->options->themeUrl('/static/images/favicon/site.webmanifest');?>">
-<link rel="mask-icon" href="<?php $this->options->themeUrl('/static/images/favicon/safari-pinned-tab.svg');?>" color="#5bbad5">
-<link rel="shortcut icon" href="<?php $this->options->themeUrl('/static/images/favicon/favicon.ico');?>">
+<?php if (file_exists(__TYPECHO_ROOT_DIR__ . '/favicon.ico')): ?>
+  <link rel="icon" href="<?php $this->options->siteUrl('favicon.ico'); ?>">
+<?php endif; ?>
+
 <meta name="msapplication-TileColor" content="#2d89ef">
-<meta name="msapplication-config" content="<?php $this->options->themeUrl('/static/images/favicon/browserconfig.xml');?>">
 <meta name="theme-color" content="#ffffff">
 
 <!-- Open Graph / Facebook -->


### PR DESCRIPTION
## Summary
- Simplify favicon handling by dropping theme static icon links
- Dynamically load `favicon.ico` from site root when present

## Testing
- `php -l usr/themes/jjj/php_modules/default_head.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac5d2b882883318c336d678a4b7db2